### PR TITLE
Support for multiprocessing with MPI pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ Currently requires and python 3.9 ish and `astropy`, `corner`, `dynesty`, `matpl
 conda create python=3.9 -n backtrack
 conda activate backtrack
 conda install pip
-pip install numpy astropy matplotlib corner dynesty novas novas_de405 orbitize seaborn
+pip install numpy astropy matplotlib corner dynesty novas novas_de405 orbitize seaborn schwimmbad
 ```

--- a/backtrack/backtrack.py
+++ b/backtrack/backtrack.py
@@ -428,12 +428,14 @@ class backtrack():
 
     def save_results(self, fileprefix='./'):
         save_dict = {'med':self.run_median, 'quant':self.run_quant, 'results':self.results}
-        file_name = f'{fileprefix}{self.target_name.replace(' ','_')}_dynestyrun_results.pkl'
+        target_label = self.target_name.replace(' ','_')
+        file_name = f'{fileprefix}{target_label}_dynestyrun_results.pkl'
         pickle.dump(save_dict, open(file_name, "wb"))
 
 
     def load_results(self, fileprefix='./'):
-        file_name = f'{fileprefix}{self.target_name.replace(' ','_')}_dynestyrun_results.pkl'
+        target_label = self.target_name.replace(' ','_')
+        file_name = f'{fileprefix}{target_label}_dynestyrun_results.pkl'
         save_dict = pickle.load(open(file_name, "rb"))
         self.run_median = save_dict['med']
         self.run_quant = save_dict['quant']


### PR DESCRIPTION
Hi @wbalmer,

Hereby the PR that adds support for multiprocessing with MPI by using an `MPIPool` instead of the regular pool from `dynasty`. In this way, it can run on a cluster with multiple nodes. I added the `mpi_pool`, `n_live`, and `resume` parameters to `fit`.

I noticed that querying the Gaia catalog did not work in combination with MPI (or perhaps some other issue related to the cluster I was using), so I added the possibility to read this from a FITS file, which is created when running `backtrack`. To get this to work, I had to restructure some of the code a bit such that the class attributes are correctly set.

Let me know if you have any questions and/or feedback!
