### PR TITLE
Added plot_radec parameter and removed envelope from trackplot

### DIFF
--- a/backtrack/backtrack.py
+++ b/backtrack/backtrack.py
@@ -384,7 +384,6 @@ class backtrack():
 
                     dsampler.run_nested(
                         dlogz=dlogz,
-                        maxiter=10000,
                         checkpoint_file='dynesty.save',
                         resume=resume,
                     )

--- a/backtrack/utils.py
+++ b/backtrack/utils.py
@@ -1,14 +1,10 @@
 # backtrack utility functions. stand on the shoulders of giants, its fun!
 
 # imports
-import orbitize
 import orbitize.system
 import numpy as np
 from scipy.stats import norm
 from scipy.special import gammainc, gammaincc, gammainccinv, gammaincinv
-import novas.compat as novas
-from novas.compat.eph_manager import ephem_open
-from astropy.coordinates import SkyCoord, Angle
 
 
 def pol2car(sep, pa, seperr, paerr, corr=np.nan):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+astropy
+astroquery
+corner
+dynesty
+matplotlib
+numpy
+novas
+novas_de405
+orbitize
+pandas
+seaborn
+schwimmbad
+scipy


### PR DESCRIPTION
Hi @wbalmer,

I was trying to fix the envelope in de left panel of the figure from `trackplot`. However, I realized that this is not feasible I think. The `fill_between` function from `pyplot` requires shared x values for the lower and upper y values. That would require interpolating the Dec values of the +1 sigma line on the RA values of the -1 sigma line (or the other way around). However, that will not work because of the helix-shaped curve. For each RA position the curve has two or more Dec positions.

So I don't think that there is a straightforward way to include the envelope and perhaps there would anyway be too much overlap of the envelope. I have removed it from the plot and instead added the `plot_radec` parameter to `generate_plots` (default: False). If set to True, `trackplot` will shown deltaRA en deltaDEC in the right panels instead of sep and PA.

As I was going through the code, I have also been making some minor style improvements here and there. And also added a requirements.txt file with the dependencies.

Let me know in case you have any feedback/questions!