### PR TITLE
Sphinx documentation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,16 +22,13 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get install pandoc
-          pip install --upgrade pip
-          pip install --upgrade numpy cython
+          pip install --upgrade pip numpy cython
           pip install flake8 pytest pytest-cov sphinx
+          pip install -r docs/requirements.txt
           # Install requirements.txt without orbitize
           pip install -r .github/workflows/requirements.txt
           git clone https://github.com/sblunt/orbitize.git $HOME/orbitize
           pip install -r $HOME/orbitize/requirements.txt
-          ls $HOME
-          pwd
-          ls
 
       - name: Lint with flake8
         run: |
@@ -40,10 +37,12 @@ jobs:
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
+      - name: Build documentation
+        run: |
+          cd docs
+          make html
+
       - name: Run pytest
         run: |
-          echo $PYTHONPATH
-          export PYTHONPATH=$HOME/orbitize
-          export PYTHONPATH=$PYTHONPATH:$HOME/work/backtrack/backtrack/
-          echo $PYTHONPATH
+          export PYTHONPATH=$HOME/orbitize:$HOME/work/backtrack/backtrack/
           pytest

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ backtracks.egg-info/
 coverage.xml
 htmlcov/
 .tox/
-*.ipynb*
 bgstar_emcee.py
 *beta_pic*
 *SAO*

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,14 @@
+version: 2
+
+sphinx:
+  configuration: docs/conf.py
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+python:
+   install:
+      - requirements: docs/requirements.txt
+      - requirements: requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
 # backtracks
-<<<<<<< Updated upstream
-Python package to fit relative astrometry with background star motion tracks.
-=======
 
 .. image:: https://img.shields.io/pypi/v/backtracks
    :target: https://pypi.python.org/pypi/backtracks
@@ -16,7 +13,6 @@ Python package to fit relative astrometry with background star motion tracks.
    :target: https://github.com/wbalmer/backtracks/blob/main/LICENSE
 
 :stars: Python package to fit relative astrometry with background star motion tracks.
->>>>>>> Stashed changes
 
 Written by Gilles Otten (@gotten), William Balmer (@wbalmer), and Tomas Stolker (@tomasstolker).
 
@@ -25,40 +21,3 @@ eDR3 Distance prior summary file from this [source](https://arxiv.org/pdf/2012.0
 Current example (HD131399Ab) uses data from Wagner+22 and Nielsen+17. Thank you to Kevin Wagner for providing the latest astrometry!
 
 Log-likelihood borrowed heavily from `orbitize!` (BSD 3-clause).
-<<<<<<< Updated upstream
-
-Currently requires and python >3.9,<3.11 and `astropy`, `corner`, `dynesty`, `matplotlib`, `numpy`, `novas`, `novas_de405`, `orbitize` and their dependencies. Note that `novas` is not supported on Windows (I use WSL for Windows to develop the code!). You can create a working environment using conda+pip via a few lines of code:
-
-```
-conda create python=3.11 -n backtracks
-conda activate backtracks
-conda install pip
-pip install backtracks
-```
-
-Then, download the test data+script and test your installation (takes a while to sample fully):
-```
-wget https://raw.githubusercontent.com/wbalmer/backtrack/main/tests/scorpions1b_orbitizelike.csv
-wget https://raw.githubusercontent.com/wbalmer/backtrack/main/tests/hd131339a.py
-python hd131339a.py
-```
-
-or, to clone the repo and install in development mode (we recommend this, as the code is a work in progress and you can easily fix bugs you will likely encounter this way):
-
-```
-conda create python=3.11 -n backtracks
-conda activate backtracks
-conda install pip
-git clone https://github.com/wbalmer/backtrack.git
-cd backtrack
-pip install -e .
-```
-
-Then, test your installation (takes a while to sample fully):
-
-```
-cd tests
-python hd131399a.py
-```
-=======
->>>>>>> Stashed changes

--- a/README.md
+++ b/README.md
@@ -1,5 +1,22 @@
 # backtracks
+<<<<<<< Updated upstream
 Python package to fit relative astrometry with background star motion tracks.
+=======
+
+.. image:: https://img.shields.io/pypi/v/backtracks
+   :target: https://pypi.python.org/pypi/backtracks
+
+.. image:: https://github.com/wbalmer/backtracks/actions/workflows/main.yml/badge.svg
+   :target: https://github.com/wbalmer/backtracks/actions
+
+.. image:: https://img.shields.io/readthedocs/backtracks
+   :target: http://backtracks.readthedocs.io
+
+.. image:: https://img.shields.io/github/license/wbalmer/backtracks
+   :target: https://github.com/wbalmer/backtracks/blob/main/LICENSE
+
+:stars: Python package to fit relative astrometry with background star motion tracks.
+>>>>>>> Stashed changes
 
 Written by Gilles Otten (@gotten), William Balmer (@wbalmer), and Tomas Stolker (@tomasstolker).
 
@@ -8,6 +25,7 @@ eDR3 Distance prior summary file from this [source](https://arxiv.org/pdf/2012.0
 Current example (HD131399Ab) uses data from Wagner+22 and Nielsen+17. Thank you to Kevin Wagner for providing the latest astrometry!
 
 Log-likelihood borrowed heavily from `orbitize!` (BSD 3-clause).
+<<<<<<< Updated upstream
 
 Currently requires and python >3.9,<3.11 and `astropy`, `corner`, `dynesty`, `matplotlib`, `numpy`, `novas`, `novas_de405`, `orbitize` and their dependencies. Note that `novas` is not supported on Windows (I use WSL for Windows to develop the code!). You can create a working environment using conda+pip via a few lines of code:
 
@@ -42,3 +60,5 @@ Then, test your installation (takes a while to sample fully):
 cd tests
 python hd131399a.py
 ```
+=======
+>>>>>>> Stashed changes

--- a/backtracks/__init__.py
+++ b/backtracks/__init__.py
@@ -2,7 +2,7 @@ from backtracks.backtracks import system
 
 __author__ = "William Balmer"
 __license__ = "BSD-3"
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 __maintainer__ = "William Balmer"
 __email__ = "wbalmer1@jhu.com"
 __status__ = "Development"

--- a/backtracks/backtracks.py
+++ b/backtracks/backtracks.py
@@ -28,6 +28,7 @@ from astropy.io import fits
 from astropy.time import Time
 from astroquery.gaia import Gaia
 from astroquery.simbad import Simbad
+from matplotlib.pyplot import Figure
 from novas.compat.eph_manager import ephem_open
 
 from schwimmbad import MPIPool
@@ -316,7 +317,11 @@ class system():
 
         return param
 
+<<<<<<< Updated upstream
     def fit(self, dlogz=0.1, npool=4, dynamic=False, nlive=500, mpi_pool=False, resume=False, sample_method='unif'):
+=======
+    def fit(self, dlogz=0.5, npool=4, dynamic=False, nlive=200, mpi_pool=False, resume=False):
+>>>>>>> Stashed changes
         """
         """
         print('[BACKTRACK INFO]: Beginning sampling, I hope')
@@ -459,7 +464,7 @@ class system():
             plot_stationary: bool = False,
             fileprefix: str = './',
             filepost: str = '.pdf',
-        ):
+        ) -> Tuple[Figure, Figure, Figure, Figure, Figure]:
         """
         """
         if ref_epoch is None:
@@ -469,11 +474,7 @@ class system():
         else:
             ref_epoch = Time(f'{ref_epoch[0]}-{ref_epoch[1]}-{ref_epoch[2]}T12:00:00', format='isot')
 
-        diagnos = diagnostic(self, fileprefix=fileprefix, filepost=filepost)
-        plx_prior(self, fileprefix=fileprefix, filepost=filepost)
-        post = posterior(self, fileprefix=fileprefix, filepost=filepost)
-
-        tracks = trackplot(
+        fig_track = trackplot(
             self,
             ref_epoch=ref_epoch.jd,
             days_backward=days_backward,
@@ -485,4 +486,9 @@ class system():
             filepost=filepost
         )
 
-        hood = neighborhood(self, fileprefix=fileprefix, filepost=filepost)
+        fig_post = posterior(self, fileprefix=fileprefix, filepost=filepost)
+        fig_diag = diagnostic(self, fileprefix=fileprefix, filepost=filepost)
+        fig_prior = plx_prior(self, fileprefix=fileprefix, filepost=filepost)
+        fig_hood = neighborhood(self, fileprefix=fileprefix, filepost=filepost)
+
+        return fig_track, fig_post, fig_diag, fig_prior, fig_hood

--- a/backtracks/backtracks.py
+++ b/backtracks/backtracks.py
@@ -317,11 +317,7 @@ class system():
 
         return param
 
-<<<<<<< Updated upstream
-    def fit(self, dlogz=0.1, npool=4, dynamic=False, nlive=500, mpi_pool=False, resume=False, sample_method='unif'):
-=======
-    def fit(self, dlogz=0.5, npool=4, dynamic=False, nlive=200, mpi_pool=False, resume=False):
->>>>>>> Stashed changes
+    def fit(self, dlogz=0.5, npool=4, dynamic=False, nlive=200, mpi_pool=False, resume=False, sample_method='unif'):
         """
         """
         print('[BACKTRACK INFO]: Beginning sampling, I hope')

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,19 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line.
+SPHINXOPTS    =
+SPHINXBUILD   = sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,69 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../'))
+
+import sphinx_readable_theme
+
+# -- Project information -----------------------------------------------------
+
+project = 'backtracks'
+copyright = '2023, William Balmer'
+author = 'William Balmer'
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.viewcode',
+    'sphinx_automodapi.automodapi',
+    'nbsphinx'
+]
+
+numpydoc_show_class_members = False
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+
+exclude_patterns = ['_build',
+                    'Thumbs.db',
+                    '.DS_Store',
+                    '.ipynb_checkpoints/*']
+
+# -- Options for HTML output -------------------------------------------------
+
+html_theme_path = [sphinx_readable_theme.get_html_theme_path()]
+html_theme = 'readable'
+
+html_theme_options = {
+    # 'github_url': 'https://github.com/wbalmer/backtracks',
+    # 'use_edit_page_button': True,
+}
+
+html_context = {
+    "github_user": "wbalmer",
+    "github_repo": "backtracks",
+    "github_version": "main",
+    "doc_path": "docs",
+}
+
+html_static_path = []
+
+html_search_language = 'en'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,13 @@
+.. _index:
+
+Documentation for *backtracks*
+==============================
+
+*backtracks* is a tool to fit relative astrometry with background star motion tracks
+
+.. toctree::
+   :maxdepth: 2
+
+   installation
+   tutorial.ipynb
+   modules

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,0 +1,30 @@
+.. _installation:
+
+Installation
+============
+
+Currently requires and python 3.9 ish and `astropy`, `corner`, `dynesty`, `matplotlib`, `numpy`, `novas`, `novas_de405`, `orbitize` and their dependencies. Note that `novas` is not supported on Windows. You can create a working environment using conda+pip via a few lines of code:
+
+.. code-block:: console
+
+    $ conda create python=3.9 -n backtrack
+    $ conda activate backtrack
+    $ conda install pip
+    $ pip install backtracks
+
+Or, to clone the repo and install in development mode (we recommend this, as the code is a work in progress and you can easily fix bugs you will likely encounter this way):
+
+.. code-block:: console
+
+    $ conda create python=3.9 -n backtrack
+    $ conda activate backtrack
+    $ conda install pip
+    $ git clone https://github.com/wbalmer/backtrack.git
+    $ cd backtrack
+    $ pip install -e .
+
+Then, test your installation:
+
+.. code-block:: python
+
+    >>> from backtracks import system

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,0 +1,9 @@
+.. _api:
+
+API documentation
+=================
+
+.. toctree::
+   :maxdepth: 4
+
+   backtracks

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,6 @@
+jupyter
+nbsphinx
+pandoc
+sphinx-automodapi
+sphinx_book_theme
+sphinx-readable-theme

--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -1,0 +1,195 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7eed1901",
+   "metadata": {},
+   "source": [
+    "# Tutorial"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09b2a5cd",
+   "metadata": {},
+   "source": [
+    "Start by downloading the astrometry data to the local working folder:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "7e2912ca-607b-40c9-b4c1-e4edc44463a7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--2023-12-19 10:22:35--  https://raw.githubusercontent.com/wbalmer/backtrack/main/tests/scorpions1b_orbitizelike.csv\n",
+      "Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.110.133, 185.199.109.133, 185.199.108.133, ...\n",
+      "Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.110.133|:443... connected.\n",
+      "HTTP request sent, awaiting response... 200 OK\n",
+      "Length: 831 [text/plain]\n",
+      "Saving to: ‘scorpions1b_orbitizelike.csv’\n",
+      "\n",
+      "scorpions1b_orbitiz 100%[===================>]     831  --.-KB/s    in 0s      \n",
+      "\n",
+      "2023-12-19 10:22:35 (99.1 MB/s) - ‘scorpions1b_orbitizelike.csv’ saved [831/831]\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "!wget https://raw.githubusercontent.com/wbalmer/backtrack/main/tests/scorpions1b_orbitizelike.csv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f8ef3ec5-449a-458d-bdc4-ce7f64053123",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from backtracks import system"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "23323c76-5999-4cf9-8f83-75e19d775d02",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[BACKTRACK INFO]: Resolved the target star 'HD 131399A' in Simbad!\n",
+      "[BACKTRACK INFO]: Resolved target's Gaia ID from Simbad, Gaia DR3 6204835284262018688\n",
+      "INFO: Query finished. [astroquery.utils.tap.core]\n",
+      "[BACKTRACK INFO]: gathered target Gaia data\n",
+      "INFO: Query finished. [astroquery.utils.tap.core]\n",
+      "[BACKTRACK INFO]: gathered 6445 Gaia objects from the 0.5 sq. deg. nearby HD 131399A\n",
+      "[BACKTRACK INFO]: Finished nearby background gaia statistics\n",
+      "[BACKTRACK INFO]: Queried distance prior parameters, L=2524.23, alpha=1.05, beta=0.62\n",
+      "[BACKTRACK INFO]: Opened ephemeris file\n",
+      "[BACKTRACK INFO]: made cat entry for host\n",
+      "[BACKTRACK INFO]: transformed cat entry for host\n"
+     ]
+    }
+   ],
+   "source": [
+    "track = system(target_name=\"HD 131399A\",\n",
+    "               candidate_file=\"scorpions1b_orbitizelike.csv\",\n",
+    "               nearby_window=0.5,\n",
+    "               fileprefix='./')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e25f5b54-25f5-43b3-91d9-67d1c48b27cb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[BACKTRACK INFO]: Beginning sampling, I hope\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "iter: 4781 | +200 | bound: 50 | nc: 1 | ncall: 21942 | eff(%): 22.910 | loglstar:   -inf < -100.256 <    inf | logz: -123.364 +/-  0.336 | dlogz:  0.002 >  0.500                                     "
+     ]
+    }
+   ],
+   "source": [
+    "results = track.fit(dlogz=0.5, npool=4, dynamic=False, nlive=200, mpi_pool=False, resume=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ee2a682a-230a-45e8-a149-93a24fa5b72f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "track.save_results(fileprefix='./')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "102c8cb3-12d9-44e3-8a11-7e092f267d2f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "track.load_results(fileprefix='./')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "2cc755fe-8f11-489b-ab0b-1b21ce76e02b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "\n",
+    "fig_track, fig_post, fig_diag, fig_prior, fig_hood = \\\n",
+    "    track.generate_plots(days_backward=3.*365.,\n",
+    "                         days_forward=3.*365,\n",
+    "                         step_size=100.,\n",
+    "                         ref_epoch=None,\n",
+    "                         plot_radec=False,\n",
+    "                         plot_stationary=True,\n",
+    "                         fileprefix='./',\n",
+    "                         filepost='.png')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ceacd47c-4f57-4c30-b1db-253559447d94",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "HD_131399A_bjprior_backtracks.png       HD_131399A_model_backtracks.png\n",
+      "HD_131399A_corner_backtracks.png        HD_131399A_nearby_gaia_distribution.png\n",
+      "HD_131399A_evidence_backtracks.png\n"
+     ]
+    }
+   ],
+   "source": [
+    "! ls *png"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_backtracks.py
+++ b/tests/test_backtracks.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 
+import dynesty
 from backtracks import system
 
 class TestBacktracks:
@@ -39,9 +40,8 @@ class TestBacktracks:
     def test_fit(self) -> None:
 
         results = self.bt_system.fit(dlogz=0.5, npool=4, dynamic=False, mpi_pool=False, nlive=100, resume=False)
-        print(type(results))
 
-        # assert isinstance(results, system)
+        assert isinstance(results, dynesty.utils.Results)
 
     def test_save(self) -> None:
 


### PR DESCRIPTION
This PR adds a setup for `sphinx` documentation. This can be locally build with `make html` in the `docs` folder. It will also automatically build on readthedocs after merging a PR. The readthedocs page should still be activated by @wbalmer, in case you agree on including these type of documentation!